### PR TITLE
feat: deploy buchgr bazel-cache

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -1,4 +1,10 @@
 {
+  "bazel-remote-cache": {
+    "renovate_datasource": "docker",
+    "renovate_depname": "buchgr/bazel-remote-cache",
+    "sha256": "sha256:1118f40525782b66b0ab1e747983a7df8918aaff7c933c51401460afba67e9f7",
+    "version": "v2.4.4"
+  },
   "mbs": {
     "renovate_datasource": "docker",
     "renovate_depname": "craigbender/cmaas",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,6 @@ jobs:
       -
         run: bazel test //... --test_output=errors --test_summary=detailed
       -
+        run: bazel build //...
+      -
         run: bazel shutdown

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-bazel-*
+/bazel-*
 MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,44 +13,20 @@ http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_
 
 # Application icon, sourced from squarespace CDN
 http_file(
+    name = "buchgr_icon",
+    sha256 = "17b0b844fd52deff5328df2ce05e12e6d754ebda75ba1065ee0aa2127f12dcab",
+    urls = [
+        "https://avatars.githubusercontent.com/u/1388179?s=1000&v=4",
+    ],
+)
+
+http_file(
     name = "maas_icon",
     sha256 = "db55a612a931a90f4a212e684b4a122e18d61c1e79cbcf26f022577bd464f5b2",
     urls = [
         "https://images.squarespace-cdn.com/content/v1/500a3673c4aa9263a8955641/1551919834344-GX7V5SG9ZDQ1E7XU6JKV/maas-logo.png",
     ],
 )
-
-
-
-#http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-#
-## from Mojang site
-#http_archive(
-#    name = "mojang_bedrock_server",
-#    build_file_content = """
-#filegroup(
-#    name="mojang_bedrock_server",
-#    srcs = glob([
-#        "resource_packs/**",
-#        "behavior_packs/**",
-#        "config/**",
-#        "definitions/**",
-#    ]) + [
-#        "allowlist.json",
-#        "bedrock_server",
-#        "bedrock_server_how_to.html",
-#        "permissions.json",
-#        "release-notes.txt",
-#        "server.properties",
-#    ],
-#    visibility = ["//visibility:public"],
-#)
-#    """,
-#    sha256 = "2e86d3f6f545fa2e4cd6736e5f12fbaf1923261232abbfe937a08d3bbe945c60",
-#    urls = [
-#        "https://www.minecraft.net/bedrockdedicatedserver/bin-linux/bedrock-server-1.21.31.04.zip",
-#    ],
-#)
 
 load_json_file = use_repo_rule("//json:load_json_file.bzl", "load_json_file")
 

--- a/spk/bazel-remote-cache/BUILD.bazel
+++ b/spk/bazel-remote-cache/BUILD.bazel
@@ -11,62 +11,41 @@ load(
     "docker_project",
     "images",
     "info_file",
-    "maintainer",
     "privilege_config",
-    "protocol_file",
     "resource_config",
-    "service_config",
 )
 
-PGCON = "postgres://maas:maas@192.168.0.159:5432/maasdb"
+PKG_SERIAL = 1
 
-MAAS_DOMAIN = "chickenandporn.com"
+# These are just here to show related text rather than just coincidentally-the-same text
+CONTAINER_NAME = "bazel-remote-cache"
 
-MAAS_CONTAINER_NAME = "cmaas"
+VOLUMENAME = "bazel-remote-cache"
 
-MAAS_PROFILE = "admin"
-
-MAAS_PASS = "admin"
-
-MAAS_EMAIL = "maas-admin@{}".format(MAAS_DOMAIN)
-
-MAAS_SSH_IMPORT_ID = "gh:chickenandpork"
-
-MAAS_URL = "http://localhost:5240/MAAS"
-
-# This is the "project" in a docker-project sense: the name of the docker-compose subdir is the
-# name of the multi-container project described in the "compose" file
-PROJECT = "bedrock"
-
-# compose_component is not leaked from the BUILD.bazel, but it used to relationships here
-COMPOSE_COMPONENT = "minecraft_bedrock"
-
-# spk_name is the name of the result -- {SPK_NAME}.spk -- which can container multiple
-# docker-projects
-SPK_NAME = "docker-minecraft-bedrock-server"
-
-# docker_compose represents a name of a docker-compose.yaml file, of which one or more is inside a "docker-project" entry
 docker_compose(
-    name = "cmaas_compose",
+    name = "buchgr_compose",
     compose = ":dockercompose",
-    path = "cmaas",
-    project_name = "cmaas",
+    path = CONTAINER_NAME,
+    project_name = CONTAINER_NAME,
 )
 
 docker_project(
-    name = "cmaas_project",
-    projects = [":cmaas_compose"],
+    name = "bazel_remote_project",
+    projects = [":buchgr_compose"],
 )
 
 # check via `bazel query //spk/minecraft-bedrock:info --output=build`
 info_file(
     name = "info",
-    package_name = "cmaas",
+    package_name = "bazel-remote-cache",
     #arch_strings = ["noarch"],
-    description = "Containerized-Maas (Craig Bender)",
+    description = "Jakob Buchgraber's Bazel Cache Service",
     maintainer = "//:chickenandpork",
     os_min_ver = "7.0-1",  # correct-format=[^\d+(\.\d+){1,2}(-\d+){1,2}$]
-    package_version = "{}-1".format(version_json["mbs"]["version"]),
+    package_version = "{}-{}".format(
+        version_json["bazel-remote-cache"]["version"].removeprefix("v"),
+        PKG_SERIAL,
+    ),
 )
 
 privilege_config(
@@ -77,14 +56,13 @@ privilege_config(
 
 resource_config(
     name = "rez",
-    resources = [":cmaas_project"],
+    resources = [":bazel_remote_project"],
 )
 
-#https://images.squarespace-cdn.com/content/v1/500a3673c4aa9263a8955641/1551919834344-GX7V5SG9ZDQ1E7XU6JKV/maas-logo.png
-# Minecraft image created by Dall-E: "in the style of Minecraft, create an image of Amakusa, Japan"
+# Logo taken from Jakob's page -- similar to how Jakob's photo is used on the docker image
 images(
     name = "icons",
-    src = "@maas_icon//file",
+    src = "@buchgr_icon//file",
 )
 
 pkg_files(
@@ -105,7 +83,7 @@ pkg_tar(
     srcs = [],
     extension = "tgz",
     package_dir = "/",
-    deps = [":cmaas_project"],
+    deps = [":bazel_remote_project"],
 )
 
 [copy_file(
@@ -122,10 +100,15 @@ write_file(
         "",
         """case "$1" in""",
         """    start)""",
+        """        docker volume ls|grep -e "\\W{0}$$" 2>/dev/null || docker volume create {0}""".format(VOLUMENAME),
         """        ;;""",
         """    stop)""",
         """        ;;""",
         """    status)""",
+        """        /usr/local/bin/docker_inspect {0} | grep -q "\\"Status\\": \\"running\\"" || exit 1""".format(CONTAINER_NAME),
+        """        ;;""",
+        """    log)""",
+        """        docker logs {0}""",
         """        ;;""",
         """esac""",
         "",
@@ -146,7 +129,7 @@ pkg_files(
 )
 
 pkg_tar(
-    name = "cmaas",
+    name = "bazel-remote-cache",
     srcs = [
         ":conf",
         ":icons.group",
@@ -155,7 +138,7 @@ pkg_tar(
         ":scripts",
     ],
     extension = "tar",
-    package_file_name = "{}.spk".format("cmaas"),
+    package_file_name = "{}.spk".format("bazel-remote-cache"),
     visibility = ["//visibility:public"],
 )
 
@@ -164,14 +147,9 @@ expand_template_rule(
     name = "dockercompose",
     out = "docker-compose.yaml",
     substitutions = {
-        "PGCON": PGCON,
-        "MAAS_DOMAIN": MAAS_DOMAIN,
-        "MAAS_CONTAINER_NAME": MAAS_CONTAINER_NAME,
-        "MAAS_PROFILE": MAAS_PROFILE,
-        "MAAS_PASS": MAAS_PASS,
-        "MAAS_EMAIL": MAAS_EMAIL,
-        "MAAS_SSH_IMPORT_ID": MAAS_SSH_IMPORT_ID,
-        "MAAS_URL": MAAS_URL,
+        "{{CONTAINER_NAME}}": CONTAINER_NAME,
+        "{{VERSION}}": version_json["bazel-remote-cache"]["version"],
+        "{{VOLUME}}": VOLUMENAME,
     },
     template = ":docker-compose.tpl",
 )

--- a/spk/bazel-remote-cache/docker-compose.tpl
+++ b/spk/bazel-remote-cache/docker-compose.tpl
@@ -1,0 +1,24 @@
+---
+version: '3.6'
+
+services:
+  bazel-remote-cache:
+    command: --max_size=1000
+    container_name: {{CONTAINER_NAME}}
+    image: buchgr/bazel-remote-cache:{{VERSION}}
+    environment:
+      BAZEL_REMOTE_DIR: "/data"
+      BAZEL_REMOTE_MAX_SIZE: 1000
+      BAZEL_REMOTE_HTTP_PORT: 8080
+      BAZEL_REMOTE_GRPC_PORT: 9092
+      BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API: "true"
+    ports:
+      - "8082:8080"
+      - "9092:9092"
+    restart: unless-stopped
+    volumes:
+      - {{VOLUME}}:/data
+
+volumes:
+  # created during start-stop-script, never deleted
+  {{VOLUME}}: {external: true}


### PR DESCRIPTION
This PR makes a trivial package of Jakob Buchgraber's Bazel-cache service.  Although the Go code is available, I took the step this time to simply trigger a docker-compose that deploys the Docker container.

Release should update (RenovateBot) when a new image is released to docker.