### PR TITLE
feat: provide nomad server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /bazel-*
 MODULE.bazel.lock
+
+# experimentation
+.tmp*

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,12 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.16.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_multitool", version = "1.2.0")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "rules_synology", version = "0.2.3")
+
+# local_path_override(module_name = "rules_synology", path = "../rules_synology")
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
@@ -30,6 +34,15 @@ http_file(
     ],
 )
 
+# an SVG icon requires rules_synology-0.2.3 or later for resize tool
+http_file(
+    name = "nomad_icon",
+    sha256 = "58ba3cd1f0a6e696482e60252c58ac132912582dc6089849936112dfd2ecc862",
+    urls = [
+        "https://hyzxph.media.zestyio.com/blog-nomad-list.svg",
+    ],
+)
+
 load_json_file = use_repo_rule("//json:load_json_file.bzl", "load_json_file")
 
 load_json_file(
@@ -37,3 +50,7 @@ load_json_file(
     src = "//:.github/renovate-regex.json",
     variable_name = "version_json",
 )
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "multitool": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-aarch64-apple-darwin.tar.xz",
+        "file": "multitool-aarch64-apple-darwin/multitool",
+        "sha256": "8f5e0cd033b0fcc128c762f8d527110433523da378619cecf40e91c1df5c0686",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-x86_64-apple-darwin.tar.xz",
+        "file": "multitool-x86_64-apple-darwin/multitool",
+        "sha256": "abde3bbbd49a09d33048e1f55cc9a8aa5dd61a13493a0b1bd5ffc2c56e5bf837",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  },
+  "nomad": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://releases.hashicorp.com/nomad/1.10.0/nomad_1.10.0_linux_arm64.zip",
+        "file": "nomad",
+        "sha256": "111b8877d11eefaae4ca4b3489e396a17a2f8a6d5115e55d341f384ae82bc603",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://releases.hashicorp.com/nomad/1.10.0/nomad_1.10.0_linux_amd64.zip",
+        "file": "nomad",
+        "sha256": "d0936673cfa026b87744d60ad21ba85db70fe792b0685bfce95ac06a98d30b9d",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
+  }
+}

--- a/spk/nomad-server/BUILD.bazel
+++ b/spk/nomad-server/BUILD.bazel
@@ -1,0 +1,337 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "data_share", "image", "images", "info_file", "maintainer", "privilege_config", "protocol_file", "resource_config", "service_config", "systemd_user_unit", "usr_local_linker")
+
+info_file(
+    name = "info",
+    package_name = "nomad",
+    arch_strings = ["denverton"],
+    description = "An easy-to-use, flexible, and performant workload orchestrator",
+    displayname="HashiCorp Nomad",
+    maintainer = "//:chickenandpork",
+    os_min_ver = "7.0-1",  # correct-format=[^\d+(\.\d+){1,2}(-\d+){1,2}$]
+    package_version = "1.10.0-1",
+    support_conf_folder=True,
+    dsmuidir="ui",
+    dsmappname=["SYNO.SDS.Nomad"],
+    os_max_ver="",
+    beta = True,
+
+    # silent_install="no"
+    # silent_uninstall="no"
+    # silent_upgrade="no"
+)
+
+# KNOWN ISSUES:
+# - systemd-user-unit doesn't copy the pkguser-<>.service.  using conf/systemd/... to workaround
+# - uninstall doesn't pre-stop the service
+# - still need a manual `sudo synosystemctl start pkg-user-nomad.service` after install (need to track down the failure)
+# - need to `sudo /var/packages/nomad/target/bin/nomad acl bootstrap` to generate an ACL token:
+# ```
+# $ sudo /var/packages/nomad/target/bin/nomad acl bootstrap
+# Accessor ID  = ...
+# Secret ID    = 12345678-90ab-cdef-0123-456789abcdef
+# Name         = Bootstrap Token
+# ```
+# The value of `Secret-ID` (not my real value) can then be used as the token on
+# http://<ServerIP>4646/ui/settings/tokens
+
+INNER_SYSTEMD_SERVICE = "pkg-user-nomad.service"
+
+service_config( name="nomad_ui_port", description="Nomad UI", dst_ports = "4646/tcp", title = "Nomad UI")
+service_config( name="nomadserver-rpc", description="nomadserver-RPC (tcp)", dst_ports = "4647/tcp", title = "Nomad Server RPC Port")
+service_config( name="nomadserver-serftcp", description="nomadserver-Serf (tcp)", dst_ports = "4648/tcp", title = "Nomad Server Serf Port")
+service_config( name="nomadserver-serfudp", description="nomadserver-Serf (udp)", dst_ports = "4648/udp", title = "Nomad Server Serf Port")
+
+protocol_file(
+    name = "protocol",
+    package_name = "nomad",
+    service_config = [
+        ":nomad_ui_port",
+        #":nomadserver-rpc",
+        #":nomadserver-serftcp",
+        #":nomadserver-serfudp",
+    ],
+)
+
+data_share(
+  name = "datashare",
+  sharename = "nomad",
+  permissions = {
+    "nomad": "rw",
+  },
+)
+
+systemd_user_unit(
+    name = "systemd",
+    # TODO: make this create a DefaultInfo() return on the rule that is picked up in
+    # resource_config() to package the unit file
+    #unit = ":nomad.service",
+)
+
+usr_local_linker(
+    name = "linker",
+    bin = [ "bin/nomad" ],
+)
+
+resource_config(
+    name = "rez",
+    resources = [":datashare", ":linker", ":protocol", ":systemd"],
+)
+
+privilege_config(
+    name = "priv",
+    groupname = "hashicorp",
+    username = "nomad",
+)
+
+pkg_files(
+    name = "conf",
+    srcs = [
+        ":nomad.service",
+        ":priv",
+        ":rez",
+    ],
+    attributes = pkg_attributes(
+        mode = "0444",
+    ),
+    prefix = "conf",
+    renames = {
+        "nomad.service": "systemd/{}".format(INNER_SYSTEMD_SERVICE),
+    },
+    visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "license",
+    srcs = [
+        ":MIT-LICENSE.txt",
+    ],
+    attributes = pkg_attributes(
+        mode = "0444",
+    ),
+    renames = {
+        "MIT-LICENSE.txt": "LICENSE",
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Create icon images
+images(
+    name = "icons",
+    src = "@nomad_icon//file",
+)
+
+APP_ICON = "package_icon_256.png"
+APP_ICON_IN_UI = "images/nomad_256.png"
+image(
+    name = "icon_256",
+    image = APP_ICON,
+    src = "@nomad_icon//file",
+    size = 256,
+)
+
+pkg_tar(
+    name = "package",
+    srcs = [
+        ":protocol",
+        #":bogus-start-file",
+        ":genstart",
+    ],
+    deps = [
+        ":package-bin",
+        ":package-ui",
+    ],
+    extension = "tgz",
+    #package_dir = "/conf",
+    remap_paths = {
+        "/nomad.sc": "/conf/nomad.sc",
+    },
+)
+
+pkg_tar(
+    name = "package-bin",
+    srcs = select({
+        "@platforms//cpu:arm64": [ "@@rules_multitool++multitool+multitool.nomad.linux_arm64//tools/nomad:linux_arm64_executable" ],
+        "@platforms//cpu:x86_64": [ "@@rules_multitool++multitool+multitool.nomad.linux_x86_64//tools/nomad:linux_x86_64_executable" ],
+	# intentionally no default to catch fenceposting
+    }) + [ "LICENSE-MariaDB-Hashicorp.txt" ],
+    extension = "tgz",
+    package_dir = "/bin",
+
+    # remap_paths are based on the full abspath of the resource, less the package_dir extension.
+    # This is why /bin/linux_x86_64_executable in the archive matches /linux_x86_64_executable
+    # and is rewritten /nomad before the package_dir is applied.
+    remap_paths = {
+        # provide both, but the matches aren't mutually-exclusive because they don't need to be.
+        # If there is a clash, it suggests that the select() is broken
+        "/linux_x86_64_executable": "/nomad",
+        "/linux_arm64_executable": "/nomad",
+    },
+)
+
+# Likely better as a basic local file
+write_file(
+  name = "genstart",
+  out = "start.sh",
+  content = [
+    "#!/bin/sh",
+    "",
+    """/var/packages/{}/target/bin/nomad agent -config "/var/packages/{}/shares/{}/etc/nomad.d/nomad.hcl" -config "/var/packages/{}/shares/{}/etc/nomad.d/" """.format(
+        "nomad",  # packagename
+        "nomad",  # packagename
+        "nomad",  # sharename
+        "nomad",  # packagename
+        "nomad",  # sharename
+    ),
+    "",
+  ],
+)
+
+# Likely better as a basic local file
+write_file(
+  name = "ui-config",
+  out = "config",
+  content = [
+    "{",
+        '".url": {',
+            '"SYNO.SDS.Nomad": {',
+                '"title": "Nomad UI",',
+                '"desc": "Nomad UI",',
+                '"icon": "{}",'.format(APP_ICON_IN_UI),
+                '"type": "url",',
+                '"url": "@NOMAD_WEB_UI_URL@"',
+            "}",
+        "}",
+    "}",
+  ],
+)
+
+pkg_tar(
+    name = "package-ui",
+    srcs = [
+      ":icon_256",
+      ":ui-config",
+    ],
+    extension = "tgz",
+    package_dir = "/ui",
+    remap_paths = {
+      "/{}".format(APP_ICON): "/{}".format(APP_ICON_IN_UI),
+    },
+)
+
+# A script rather than a static file to allow replacement of the IP on the interface that is the
+# path to the default route.  Will need to see whether it works with /dev/bondX interfaces
+#
+# Likely better as a basic local file
+write_file(
+    name = "install_uifile_script",
+    out = "install_uifile.sh",
+    content = [
+        "#!/bin/sh",
+        "",
+        """SYNOLOGY_IP=$(ip route get "$(ip route show 0.0.0.0/0 | grep -oP 'via \\K\\S+')" | grep -oP 'src \\K\\S+'|sed -e 's/src //g')""",
+
+        "",
+        """tee "$SYNOPKG_TEMP_LOGFILE" <<EOF""",
+        "[",
+        "  {",
+        """    "step_title": "Nomad Agent Configuration",""",
+        """    "items": [""",
+        "      {",
+        """        "type": "textfield",""",
+        """        "desc": "Nomad Web UI URL",""",
+        """        "subitems": [""",
+        "          {",
+        """            "key": "pkgwizard_nomad_web_ui_url",""",
+        """            "defaultValue": "http://$SYNOLOGY_IP:4646" """,
+        "          }",
+        "        ]",
+        "      }",
+        "    ]",
+        "  }",
+        "];",
+        "EOF",
+        "",
+        "exit 0",
+        "",
+    ],
+)
+
+pkg_tar(
+    name = "wizard_uifiles",
+    srcs = [
+      ":install_uifile_script",
+    ],
+    extension = "tgz",
+    package_dir = "/WIZARD_UIFILES",
+)
+
+# Like the other two, this is likely better as a basic local file
+write_file(
+    name = "sss",
+    out = "start-stop-status",
+    content = [
+        "#!/bin/bash",
+        "",
+        """case "$1" in""",
+        "    start)",
+        "            synosystemctl start {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    stop)",
+        "            synosystemctl stop {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    status)",
+        "            synosystemctl get-active-status {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    log)",
+        """        echo "" """,
+        "        ;;",
+        "    *)",
+        """        echo "Usage: $0 {start|stop|status}" >&2""",
+        "        exit 1",
+        "        ;;",
+        "esac",
+    ],
+)
+
+NOMAD_REQUIRED_SCRIPTS = [ f for f in SPK_REQUIRED_SCRIPTS if f not in [ "postinst", "postuninst", "start_stop_status" ]]
+
+[copy_file(
+    name = "stub_{}".format(f),
+    src = "@rules_synology//synology:stub_script",
+    out = f,
+) for f in NOMAD_REQUIRED_SCRIPTS]
+
+pkg_files(
+    name = "scripts",
+    srcs = [":sss", ":postinst", ":postuninst" ] + [":stub_{}".format(f) for f in NOMAD_REQUIRED_SCRIPTS],
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
+    prefix = "scripts",
+)
+
+pkg_tar(
+    name = "spk",
+    srcs = [
+        ":conf",
+        ":icons",
+        ":info",
+        ":license",
+        ":package",
+        ":scripts",
+        "@rules_pkg//pkg:verify_archive_test_main.py.tpl",
+    ],
+    deps = [
+        #":scripts",
+        ":wizard_uifiles",
+    ],
+    extension = "tar",
+    package_file_name = "nomadserver.spk",
+    visibility = ["//visibility:public"],
+)
+
+

--- a/spk/nomad-server/LICENSE-MariaDB-Hashicorp.txt
+++ b/spk/nomad-server/LICENSE-MariaDB-Hashicorp.txt
@@ -1,0 +1,92 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             HashiCorp, Inc.
+Licensed Work:        Nomad Version 1.7.0 or later. The Licensed Work is (c) 2024
+                      HashiCorp, Inc.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes
+                      of this license:
+
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support
+                      arrangements, that significantly overlaps with the capabilities
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your
+                      Product is not a competitive offering when You first make it
+                      generally available, it will not become a competitive offering
+                      later due to HashiCorp releasing a new version of the Licensed
+                      Work with additional capabilities. In addition, Products that
+                      are not provided on a paid basis are not competitive.
+
+                      "Product" means software that is offered to end users to manage
+                      in their own environments or offered as a service on a hosted
+                      basis.
+
+                      "Embedded" means including the source code or executable code
+                      from the Licensed Work in a competitive offering. "Embedded"
+                      also means packaging the competitive offering in such a way
+                      that the Licensed Work must be accessed or downloaded for the
+                      competitive offering to operate.
+
+                      Hosting or using the Licensed Work(s) for internal purposes
+                      within an organization is not considered a competitive
+                      offering. HashiCorp considers your organization to include all
+                      of your affiliates under common control.
+
+                      For binding interpretive guidance on using HashiCorp products
+                      under the Business Source License, please visit our FAQ.
+                      (https://www.hashicorp.com/license-faq)
+Change Date:          Four years from the date the Licensed Work is published.
+Change License:       MPL 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact licensing@hashicorp.com.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/spk/nomad-server/MIT-LICENSE.txt
+++ b/spk/nomad-server/MIT-LICENSE.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 Allan Clark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For Nomad binary please refer to https://github.com/hashicorp/nomad/blob/main/LICENSE.

--- a/spk/nomad-server/nomad.service
+++ b/spk/nomad-server/nomad.service
@@ -1,0 +1,16 @@
+# based on https://github.com/hashicorp/nomad/issues/11618#issue-1071925408
+[Unit]
+Description=nomad
+Documentation=https://www.nomadproject.io/docs/
+After=network-online.target
+
+[Service]
+Type=simple
+Slice=nomad.slice
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/var/packages/nomad/target/bin/nomad agent -config "/var/packages/nomad/shares/nomad/etc/nomad.d/nomad.hcl" -config "/var/packages/nomad/shares/nomad/etc/nomad.d/"
+ExecStop=/bin/kill $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5

--- a/spk/nomad-server/postinst
+++ b/spk/nomad-server/postinst
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -e
+
+export NOMAD_SHARE_DIR="/var/packages/$SYNOPKG_PKGNAME/shares/nomad"
+mkdir -p "${NOMAD_SHARE_DIR}/var/log/nomad"
+LOG_FILE="${NOMAD_SHARE_DIR}/var/log/nomad/install.log"
+
+echo "$(date --iso-8601=second) Starting postinst with: NOMAD_SHARE_DIR=${NOMAD_SHARE_DIR}" >${LOG_FILE}
+
+NOMAD_WEB_UI_URL_CONFIG_FILE="/var/packages/$SYNOPKG_PKGNAME/etc/nomad_web_ui_url_config"
+if [ ! -z "$pkgwizard_nomad_web_ui_url" ]; then
+    # new install
+    NOMAD_WEB_UI_URL="$pkgwizard_nomad_web_ui_url"
+elif [ -f "$NOMAD_WEB_UI_URL_CONFIG_FILE" ]; then
+    # upgrade
+    NOMAD_WEB_UI_URL=$(grep -v '^#' $NOMAD_WEB_UI_URL_CONFIG_FILE | grep -e "NOMAD_WEB_UI_URL" | sed -e 's/.*=//')
+fi
+
+echo "NOMAD_WEB_UI_URL=$NOMAD_WEB_UI_URL" > $NOMAD_WEB_UI_URL_CONFIG_FILE
+
+if [ -f "$SYNOPKG_PKGDEST/ui/config" ]; then
+    echo "$(date --iso-8601=second) Updating variables in $SYNOPKG_PKGDEST/ui/config to ${NPMAD_WEB_UI_URL}" >>${LOG_FILE}
+    NOMAD_WEB_UI_URL=${NOMAD_WEB_UI_URL////\\/}
+    sed -i "s/@NOMAD_WEB_UI_URL@/$NOMAD_WEB_UI_URL/g" "$SYNOPKG_PKGDEST/ui/config"
+fi
+
+if [ "$SYNOPKG_PKG_STATUS" = "INSTALL" ]; then
+  echo "$(date --iso-8601=second) Installing Nomad" >>${LOG_FILE}
+
+  echo "$(date --iso-8601=second) Creating ${NOMAD_SHARE_DIR}/var/lib/nomad" >>${LOG_FILE}
+  mkdir -p "${NOMAD_SHARE_DIR}/var/lib/nomad"
+
+  echo "$(date --iso-8601=second) Creating ${NOMAD_SHARE_DIR}/etc/nomad.d" >>${LOG_FILE}
+  mkdir -p "${NOMAD_SHARE_DIR}/etc/nomad.d"
+
+  NOMAD_CONFIG_FILE="${NOMAD_SHARE_DIR}/etc/nomad.d/nomad.hcl"
+  rm -rf ${NOMAD_CONFIG_FILE}
+
+  if [ ! -f "${NOMAD_CONFIG_FILE}" ]; then
+    cat <<EOF > "${NOMAD_CONFIG_FILE}"
+data_dir="${NOMAD_SHARE_DIR}/var/lib/nomad"
+server {
+  enabled = true
+  bootstrap_expect = 1
+}
+client {
+  enabled = true
+}
+acl {
+  enabled = true
+}
+plugin "raw_exec" {
+  config {
+    enabled = true
+  }
+}
+plugin "docker" {
+  config {
+    allow_privileged = true
+    volumes {
+      # required for bind mounting host directories
+      enabled = true
+    }
+  }
+}
+EOF
+    echo "$(date --iso-8601=second) Completed creation of ${NOMAD_SHARE_DIR}/etc/nomad.d" >>${LOG_FILE}
+  else
+    echo "$(date --iso-8601=second) Skip creating ${NOMAD_CONFIG_FILE} due to existing file." >>${LOG_FILE}
+  fi;
+fi;
+
+echo "$(date --iso-8601=second) Installation complete" >>${LOG_FILE}
+
+exit 0

--- a/spk/nomad-server/postuninst
+++ b/spk/nomad-server/postuninst
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$SYNOPKG_PKG_STATUS" = "UNINSTALL" ]; then
+    rm -f /var/packages/$SYNOPKG_PKGNAME/etc/nomad_web_ui_url_config
+fi
+
+exit 0

--- a/spk/nomad-server/tests/BUILD.bazel
+++ b/spk/nomad-server/tests/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_pkg//pkg:verify_archive.bzl", "verify_archive_test")
+load("@rules_synology//:defs.bzl", "spk_component")
+
+
+copy_file(
+    name = "spk",
+    src = "//spk/nomad-server:spk",
+    out = "spk.tar",
+)
+
+verify_archive_test(
+    name = "spk_container_contains_user_unit",
+    max_size = 30,
+    must_contain = [
+        "conf/systemd/pkg-user-nomad.service",
+    ],
+    target = ":spk",
+)
+


### PR DESCRIPTION
This PR defines a near-clean deployment of single-replica (ie dev-mode) nomad agent (server/client) on a single Synology.  Later efforts can clean this up and/or provide more hooks for config at install/update time.

`rules_synology-0.2.3` needed for build