### PR TITLE
feat: extend nomad server mdns config

### DIFF
--- a/spk/nomad-server/BUILD.bazel
+++ b/spk/nomad-server/BUILD.bazel
@@ -275,6 +275,10 @@ write_file(
     out = "start-stop-status",
     content = [
         "#!/bin/bash",
+        #"",
+        #"# FIXME",
+        #"exec 2>>/tmp/nomad-sss",
+        #"set -x",
         "",
         """case "$1" in""",
         "    start)",
@@ -289,6 +293,17 @@ write_file(
         "    log)",
         """        echo "" """,
         "        ;;",
+        "    preflight)",
+        """            # not reachable via "sudo systemctl preflight nomad""",
+        """            # only via "sudo /var/packages/nomad/scripts/start-stop-status preflight""",
+        "            ( set -x  # FIXME ",
+        "            ls -al /usr/local/lib/systemd/system/pkg-user-nomad.service",
+        "            ls -al /usr/local/lib/systemd/system/pkgctl-nomad.service",
+        "            systemctl list-units | grep pkg-user-nomad.service",
+        "            systemctl list-units | grep pkgctl-nomad.service",
+        "            systemctl list-units | grep nomad.slice",
+        "            )",
+        "        ;;",
         "    *)",
         """        echo "Usage: $0 {start|stop|status}" >&2""",
         "        exit 1",
@@ -297,7 +312,7 @@ write_file(
     ],
 )
 
-NOMAD_REQUIRED_SCRIPTS = [ f for f in SPK_REQUIRED_SCRIPTS if f not in [ "postinst", "postuninst", "start_stop_status" ]]
+NOMAD_REQUIRED_SCRIPTS = [ f for f in SPK_REQUIRED_SCRIPTS if f not in [ "postinst", "postuninst", "preuninst", "start_stop_status" ]]
 
 [copy_file(
     name = "stub_{}".format(f),

--- a/spk/nomad-server/BUILD.bazel
+++ b/spk/nomad-server/BUILD.bazel
@@ -139,9 +139,11 @@ pkg_tar(
         ":protocol",
         #":bogus-start-file",
         ":genstart",
+        "example-nomad-client-config",
     ],
     deps = [
         ":package-bin",
+        ":package-etc",
         ":package-ui",
     ],
     extension = "tgz",
@@ -170,6 +172,13 @@ pkg_tar(
         "/linux_x86_64_executable": "/nomad",
         "/linux_arm64_executable": "/nomad",
     },
+)
+
+pkg_tar(
+    name = "package-etc",
+    srcs = [ "nomad-avahi.service" ],
+    extension = "tgz",
+    package_dir = "/etc",
 )
 
 # Likely better as a basic local file
@@ -283,9 +292,12 @@ write_file(
         """case "$1" in""",
         "    start)",
         "            synosystemctl start {}".format(INNER_SYSTEMD_SERVICE),
+        # avahi sees a file -- not a link -- changing, so automatically reacts to the new advert
+        "            cp /var/packages/nomad/target/etc/nomad-avahi.service /etc/avahi/services/nomad.service",
         "        ;;",
         "    stop)",
         "            synosystemctl stop {}".format(INNER_SYSTEMD_SERVICE),
+        "            rm /etc/avahi/services/nomad.service",
         "        ;;",
         "    status)",
         "            synosystemctl get-active-status {}".format(INNER_SYSTEMD_SERVICE),

--- a/spk/nomad-server/example-nomad-client-config
+++ b/spk/nomad-server/example-nomad-client-config
@@ -1,0 +1,23 @@
+# Example nomad agent config file for a client-only connection to an advertised nomad in server mode.
+#
+# This leverages the expected mDNS advertisement to find the nomad server.  We may choose to use
+# the "advertise" block in the config, but these are really indications of where to connect once
+# the server is found: "yo, you connected to me, but <redirect> really use {this} IP/port".  The
+# "advertise" block makes little sense in a client-only mode, since there should likely be no
+# second-order client connecting through to the server.
+#
+# this example server_join matches the data published to mDNS (Avahi, DNS-SD) by the server config.
+
+log_level = "INFO"
+data_dir  = "/opt/nomad"
+
+client {
+  enabled = true
+}
+
+# Join Nomad servers via mDNS using go-discover
+server_join {
+  retry_join = ["provider=mdns service=_nomad-rpc.local"]
+  retry_max = 5
+  retry_interval = "15s"
+}

--- a/spk/nomad-server/nomad-avahi.service
+++ b/spk/nomad-server/nomad-avahi.service
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+
+<service-group>
+  <name replace-wildcards="yes">%h Nomad</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>4646</port>
+    <!-- <host-name>nomad.local</host-name> -->
+  </service>
+  <service>
+    <type>_nomad-rpc._tcp</type>
+    <port>4647</port>
+  </service>
+</service-group>

--- a/spk/nomad-server/postinst
+++ b/spk/nomad-server/postinst
@@ -2,8 +2,9 @@
 set -e
 
 export NOMAD_SHARE_DIR="/var/packages/$SYNOPKG_PKGNAME/shares/nomad"
-mkdir -p "${NOMAD_SHARE_DIR}/var/log/nomad"
-LOG_FILE="${NOMAD_SHARE_DIR}/var/log/nomad/install.log"
+LOG_DIR="/var/packages/$SYNOPKG_PKGNAME/var/log"
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/postinst.log"
 
 echo "$(date --iso-8601=second) Starting postinst with: NOMAD_SHARE_DIR=${NOMAD_SHARE_DIR}" >${LOG_FILE}
 
@@ -19,7 +20,7 @@ fi
 echo "NOMAD_WEB_UI_URL=$NOMAD_WEB_UI_URL" > $NOMAD_WEB_UI_URL_CONFIG_FILE
 
 if [ -f "$SYNOPKG_PKGDEST/ui/config" ]; then
-    echo "$(date --iso-8601=second) Updating variables in $SYNOPKG_PKGDEST/ui/config to ${NPMAD_WEB_UI_URL}" >>${LOG_FILE}
+    echo "$(date --iso-8601=second) Updating variables in $SYNOPKG_PKGDEST/ui/config to ${NOMAD_WEB_UI_URL}" >>${LOG_FILE}
     NOMAD_WEB_UI_URL=${NOMAD_WEB_UI_URL////\\/}
     sed -i "s/@NOMAD_WEB_UI_URL@/$NOMAD_WEB_UI_URL/g" "$SYNOPKG_PKGDEST/ui/config"
 fi

--- a/spk/nomad-server/preuninst
+++ b/spk/nomad-server/preuninst
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+export NOMAD_SHARE_DIR="/var/packages/$SYNOPKG_PKGNAME/shares/nomad"
+
+# > Please save your package log under /var/packages/[package_id]/var/ (e.g., /var/packages/TextEditor/var/log/texteditor.log)
+# https://help.synology.com/developer-guide/resource_acquisition/syslog_config.html
+
+#LOG_DIR="/var/packages/$SYNOPKG_PKGNAME/var/log"
+LOG_DIR="/var/log/nomad"  # FIXME
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/preuninst.log"
+
+echo "$(date --iso-8601=second) Starting preuninst with: NOMAD_SHARE_DIR=${NOMAD_SHARE_DIR}" >${LOG_FILE}
+
+# We do not remove ${NOMAD_SHARE_DIR}/var/lib/nomad nor ${NOMAD_SHARE_DIR}/etc/nomad.d because
+# they're created where files may persist
+
+# ensure stopped before remove: empirically this doesn't get done for us
+# (but uninstall does indirectly stop the service)
+/usr/syno/bin/synosystemctl uninstall pkgctl-nomad.service 
+/usr/syno/bin/synosystemctl uninstall pkg-user-nomad.service 
+
+echo "$(date --iso-8601=second) PreUnInst complete" >>${LOG_FILE}
+
+exit 0


### PR DESCRIPTION
This PR includes a config to automatically publish the nomad server to MDNS on start and stop to facilitate discovery using the service=mdns provider in the server-join with an example config file `example-nomad-client-config` provided