### PR TITLE
fix: expand consul (tcp/8500 only) to all interfaces

### DIFF
--- a/spk/consul/consul.service
+++ b/spk/consul/consul.service
@@ -6,7 +6,7 @@ After=network-online.target
 Type=simple
 Slice=consul.slice
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/var/packages/consul/target/bin/consul agent -dev -http-port=8500
+ExecStart=/var/packages/consul/target/bin/consul agent -dev -http-port=8500 -client=0.0.0.0
 ExecStop=/bin/kill $MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
When working with consul-published services, I needed to see the UI to see why various services were not publishing.  Nothing exactly as expected, but this PR helps me resolve issues.