### PR TITLE
feat: provide Victoria Metrics

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -151,6 +151,15 @@ http_file(
     ],
 )
 
+# VictoriaMetrics icon - from the official LandingPages
+http_file(
+    name = "vm_icon",
+    sha256 = "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
+    urls = [
+        "https://raw.githubusercontent.com/VictoriaMetrics/LandingPages/master/images/logos/victoriametrics_logo_v1.png",
+    ],
+)
+
 load_json_file = use_repo_rule("//json:load_json_file.bzl", "load_json_file")
 
 load_json_file(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -154,9 +154,9 @@ http_file(
 # VictoriaMetrics icon - from the official LandingPages
 http_file(
     name = "vm_icon",
-    sha256 = "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
+    sha256 = "85df5ca3735331bf36956aadbfec5f49772a3097381db356523682d8b15750a0",
     urls = [
-        "https://raw.githubusercontent.com/VictoriaMetrics/LandingPages/master/images/logos/victoriametrics_logo_v1.png",
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/victoriametrics.png",
     ],
 )
 

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -66,7 +66,7 @@
         "kind": "archive",
         "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.142.0/victoria-metrics-linux-arm64-v1.142.0.tar.gz",
         "file": "victoria-metrics-prod",
-        "sha256": "8f092f430a7919288c4ca9ca4f5aacbafcf06db82f6f4570c014c3dd33578c86",
+        "sha256": "6051937d5cab34eb3f02171e0f68e2ad8119ce368c8e7d4e766739e5afc002a2",
         "os": "linux",
         "cpu": "arm64"
       },

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -59,5 +59,25 @@
         "cpu": "x86_64"
       }
     ]
+  },
+  "victoria-metrics": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.142.0/victoria-metrics-linux-arm64-v1.142.0.tar.gz",
+        "file": "victoria-metrics-prod",
+        "sha256": "8f092f430a7919288c4ca9ca4f5aacbafcf06db82f6f4570c014c3dd33578c86",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v1.142.0/victoria-metrics-linux-amd64-v1.142.0.tar.gz",
+        "file": "victoria-metrics-prod",
+        "sha256": "878e09069184d4cc86297e1f0574f2a78f5ebfce87dd1d32b286abf13aad4f85",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
   }
 }

--- a/spk/victoriametrics/BUILD.bazel
+++ b/spk/victoriametrics/BUILD.bazel
@@ -108,17 +108,6 @@ images(
     src = "@vm_icon//file",
 )
 
-APP_ICON = "package_icon_256.png"
-
-APP_ICON_IN_UI = "images/victoriametrics_256.png"
-
-image(
-    name = "icon_256",
-    size = 256,
-    src = "@vm_icon//file",
-    image = APP_ICON,
-)
-
 pkg_tar(
     name = "package",
     srcs = [
@@ -213,7 +202,6 @@ pkg_tar(
         ":info",
         ":package",
         ":scripts",
-        ":icon_256",
         "@rules_pkg//pkg:verify_archive_test_main.py.tpl",
     ],
     extension = "tar",

--- a/spk/victoriametrics/BUILD.bazel
+++ b/spk/victoriametrics/BUILD.bazel
@@ -1,0 +1,222 @@
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "data_share", "image", "images", "info_file", "maintainer", "privilege_config", "protocol_file", "resource_config", "service_config", "systemd_user_unit", "usr_local_linker")
+
+#
+# VictoriaMetrics - single binary time-series database
+#
+# VictoriaMetrics is a fast, cost-effective and scalable open source time series
+# database. It is compatible with the Prometheus remote write API and query API,
+# so it can be used as long-term storage for Prometheus or standalone.
+#
+# Single binary deployment: all functionality (ingestion, storage, querying,
+# admin UI) runs in one process with flags like:
+#   -retentionPeriod=1month
+#   -storageDataPath=/data
+#
+# Default ports:
+#   8428 - HTTP API (ingestion at /api/v1/write, query at /api/v1/read)
+#
+info_file(
+    name = "info",
+    package_name = "victoriametrics",
+    arch_strings = ["denverton"],
+    beta = True,
+    description = "Fast, cost-effective and scalable open source time series database. Compatible with Prometheus.",
+    displayname = "VictoriaMetrics",
+    maintainer = "//:chickenandpork",
+    os_min_ver = "7.0-1",  # correct-format=[^\d+(\.\d+){1,2}(-\d+){1,2}$]
+    package_version = "1.142.0-1",
+    support_conf_folder = True,
+)
+
+INNER_SYSTEMD_SERVICE = "pkg-user-victoriametrics.service"
+
+service_config(
+    name = "victoriametrics_http",
+    description = "VictoriaMetrics HTTP API",
+    dst_ports = "8428/tcp",
+    title = "VictoriaMetrics HTTP API",
+)
+
+protocol_file(
+    name = "protocol",
+    package_name = "victoriametrics",
+    service_config = [
+        ":victoriametrics_http",
+    ],
+)
+
+data_share(
+    name = "datashare",
+    permissions = {
+        "victoriametrics": "rw",
+    },
+    sharename = "victoriametrics",
+)
+
+systemd_user_unit(
+    name = "systemd",
+    # TODO: make this create a DefaultInfo() return on the rule that is picked up in
+    # resource_config() to package the unit file
+)
+
+usr_local_linker(
+    name = "linker",
+    bin = ["bin/victoria-metrics"],
+)
+
+resource_config(
+    name = "rez",
+    resources = [
+        ":datashare",
+        ":linker",
+        ":protocol",
+        ":systemd",
+    ],
+)
+
+privilege_config(
+    name = "priv",
+    groupname = "victoriametrics",
+    username = "victoriametrics",
+)
+
+pkg_files(
+    name = "conf",
+    srcs = [
+        ":victoriametrics.service",
+        ":priv",
+        ":rez",
+    ],
+    attributes = pkg_attributes(
+        mode = "0444",
+    ),
+    prefix = "conf",
+    renames = {
+        "victoriametrics.service": "systemd/{}".format(INNER_SYSTEMD_SERVICE),
+    },
+    visibility = ["//visibility:public"],
+)
+
+# Create icon images
+images(
+    name = "icons",
+    src = "@vm_icon//file",
+)
+
+APP_ICON = "package_icon_256.png"
+
+APP_ICON_IN_UI = "images/victoriametrics_256.png"
+
+image(
+    name = "icon_256",
+    size = 256,
+    src = "@vm_icon//file",
+    image = APP_ICON,
+)
+
+pkg_tar(
+    name = "package",
+    srcs = [
+        ":protocol",
+    ],
+    extension = "tgz",
+    package_dir = "/",
+    deps = [
+        ":package-bin",
+    ],
+)
+
+pkg_tar(
+    name = "package-bin",
+    srcs = select({
+        "@platforms//cpu:arm64": ["@@rules_multitool++multitool+multitool.victoria-metrics.linux_arm64//tools/victoria-metrics:linux_arm64_executable"],
+        "@platforms//cpu:x86_64": ["@@rules_multitool++multitool+multitool.victoria-metrics.linux_x86_64//tools/victoria-metrics:linux_x86_64_executable"],
+        # intentionally no default to catch fenceposting
+    }),
+    extension = "tgz",
+    package_dir = "/bin",
+
+    # Remap victoria-metrics-prod -> victoriametrics
+    remap_paths = {
+        "/linux_x86_64_executable": "/victoria-metrics",
+        "/linux_arm64_executable": "/victoria-metrics",
+    },
+)
+
+# start-stop-status script
+write_file(
+    name = "sss",
+    out = "start-stop-status",
+    content = [
+        "#!/bin/bash",
+        "",
+        """case "$1" in""",
+        "    start)",
+        "            synosystemctl start {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    stop)",
+        "            synosystemctl stop {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    status)",
+        "            synosystemctl get-active-status {}".format(INNER_SYSTEMD_SERVICE),
+        "        ;;",
+        "    log)",
+        """        echo "" """,
+        "        ;;",
+        "    preflight)",
+        """            # not reachable via "sudo systemctl preflight victoriametrics""",
+        """            # only via "sudo /var/packages/victoriametrics/scripts/start-stop-status preflight""",
+        "            ( set -x  # FIXME ",
+        "            ls -al /usr/local/lib/systemd/system/pkg-user-victoriametrics.service",
+        "            ls -al /usr/local/lib/systemd/system/pkgctl-victoriametrics.service",
+        "            systemctl list-units | grep pkg-user-victoriametrics.service",
+        "            systemctl list-units | grep pkgctl-victoriametrics.service",
+        "            systemctl list-units | grep victoriametrics.slice",
+        "            )",
+        "        ;;",
+        "    *)",
+        """        echo "Usage: $0 {start|stop|status}" >&2""",
+        "        exit 1",
+        "        ;;",
+        "esac",
+    ],
+)
+
+# Stub out scripts we don't need to customize
+NOMAD_REQUIRED_SCRIPTS = [f for f in SPK_REQUIRED_SCRIPTS if f not in ["start_stop_status"]]
+
+[copy_file(
+    name = "stub_{}".format(f),
+    src = "@rules_synology//synology:stub_script",
+    out = f,
+) for f in NOMAD_REQUIRED_SCRIPTS]
+
+pkg_files(
+    name = "scripts",
+    srcs = [":sss"] + [":stub_{}".format(f) for f in NOMAD_REQUIRED_SCRIPTS],
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
+    prefix = "scripts",
+)
+
+pkg_tar(
+    name = "spk",
+    srcs = [
+        ":conf",
+        ":icons",
+        ":info",
+        ":package",
+        ":scripts",
+        ":icon_256",
+        "@rules_pkg//pkg:verify_archive_test_main.py.tpl",
+    ],
+    extension = "tar",
+    package_file_name = "victoriametrics.spk",
+    visibility = ["//visibility:public"],
+)

--- a/spk/victoriametrics/README.md
+++ b/spk/victoriametrics/README.md
@@ -1,0 +1,56 @@
+# VictoriaMetrics SPK
+
+[VictoriaMetrics](https://victoriametrics.com/) packaged as a Synology Package (SPK) for single-node deployment.
+
+## About
+
+VictoriaMetrics is a fast, cost-effective and scalable open source time series database. It is compatible with the Prometheus remote write API and query API.
+
+### Single Binary Deployment
+
+All functionality (ingestion, storage, querying, admin UI) runs in one process:
+
+```bash
+/var/packages/victoriametrics/target/bin/victoria-metrics \
+    -retentionPeriod=1month \
+    -storageDataPath=/var/packages/victoriametrics/shares/victoriametrics/data
+```
+
+### Ports
+
+- **8428** - HTTP API (ingestion at `/api/v1/write`, query at `/api/v1/read`, admin UI at `/`)
+
+### Prometheus Integration
+
+VictoriaMetrics accepts Prometheus remote write:
+
+```
+POST http://<synology-ip>:8428/api/v1/write
+```
+
+Query via:
+
+```
+GET http://<synology-ip>:8428/api/v1/query?query=up
+```
+
+## Installation
+
+Build the SPK:
+
+```bash
+bazel build spk/victoriametrics:spk
+```
+
+The resulting `.spk` file will be at `bazel-bin/spk/victoriametrics/victoriametrics.spk`.
+
+Install via Synology Package Center or:
+
+```bash
+sudo synopkg install bazel-bin/spk/victoriametrics/victoriametrics.spk
+```
+
+## Architecture Support
+
+- `denverton` (x86_64) - tested
+- `armv8` (ARM64) - included in build

--- a/spk/victoriametrics/victoriametrics.service
+++ b/spk/victoriametrics/victoriametrics.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=VictoriaMetrics time-series database
+Documentation=https://victoriametrics.com/
+After=network-online.target
+
+[Service]
+Type=simple
+Slice=victoriametrics.slice
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/var/packages/victoriametrics/target/bin/victoria-metrics \
+    -retentionPeriod=1month \
+    -storageDataPath=/var/packages/victoriametrics/shares/victoriametrics/data \
+    -selfStat
+ExecStop=/bin/kill $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
I was looking at prometheus on my NAS, but I feel Victoria Metrics might be a better option: we're using it at my work, and it runs lighter yet feels more responsive.  It feels a bit more specialized to the workload.

This is merely a packaging of prebuilt, we may need to advance to cross-compile ultimately (https://github.com/victoriametrics/VictoriaMetrics -- a Go package).