### PR TITLE
renovate/reconfigure

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,8 @@
   ],
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigestsToSemver` to renovate's extends list.

This ensures GitHub Action references are pinned to semver-compatible digests.